### PR TITLE
Update title displayed in tab for each page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,10 @@
     import member4Img from "$lib/images/contacts/william_m.jpg";
 </script>
 
+<svelte:head>
+    <title>LiTHe Hax</title>
+</svelte:head>
+
 <Section>
     <h1>About us</h1>
     <p>

--- a/src/routes/christmas-2024/+page.svelte
+++ b/src/routes/christmas-2024/+page.svelte
@@ -55,6 +55,10 @@
     });
 </script>
 
+<svelte:head>
+    <title>LiTHe Hax - Christmas 2024</title>
+</svelte:head>
+
 <Section isThin>
     <h1>Christmas CTF 2024 Leaderboard</h1>
     {#if hasError}

--- a/src/routes/new-member/+page.svelte
+++ b/src/routes/new-member/+page.svelte
@@ -62,6 +62,10 @@
     }
 </script>
 
+<svelte:head>
+    <title>LiTHe Hax - Member</title>
+</svelte:head>
+
 <Section isThin>
     <h1>Become a member</h1>
     <p>


### PR DESCRIPTION
This PR updates the title for each page, so that instead of the tab text being "lithehax.se/" it is one of the following:
- "LiTHe Hax"
- "LiTHe Hax - Member"
- "LiTHe Hax - Christmas 2024"