### PR TITLE
Update event page title to match new event page

### DIFF
--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <svelte:head>
-    <title>LiTHe Hax CTF</title>
+    <title>LiTHe Hax - Events</title>
 </svelte:head>
 
 <Section isThin>


### PR DESCRIPTION
Update event page title to `LiTHe Hax - Events` instead of `LiTHe Hax CTF`.
 
**Before:**
![before](https://github.com/user-attachments/assets/d80c507a-63c0-4aa1-b6f3-440190dbafcc)
**After:**
![after](https://github.com/user-attachments/assets/42984388-844b-4f5f-bc10-34d19fae4b07)
