### PR TITLE
Run workflow on all branches but only deploy on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to GitHub Pages
 
-on:
-  push:
-    branches: 'main'
+on: push
 
 jobs:
   build_site:
@@ -31,6 +29,7 @@ jobs:
           # this should match the `pages` option in your adapter-static options
           path: 'build/'
   deploy:
+    if: github.ref == 'refs/heads/main'
     needs: build_site
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This PR enables the workflow "build_site" to run on every branch and disables the workflow "deploy" from running on any branch other than main. This is done so that PRs can be blocked from merging if the website cannot be built successfully.